### PR TITLE
Add tensor transfer functions between CPU and CUDA devices

### DIFF
--- a/Test/TorchSharp.cs
+++ b/Test/TorchSharp.cs
@@ -110,6 +110,40 @@ namespace TorchSharp.Test
         }
 
         [TestMethod]
+        public void CopyCpuToCuda()
+        {
+            var cpu = FloatTensor.Ones(new long[] { 2, 2 });
+            Assert.AreEqual(cpu.Device, "cpu");
+
+            var cuda = cpu.Cuda();
+            Assert.AreEqual(cuda.Device, "cuda");
+
+            // Copy back to CPU to inspect the elements
+            cpu = cuda.Cpu();
+            var data = cpu.Data;
+            for (int i = 0; i < 4; i++)
+            {
+                Assert.AreEqual(data[i], 1);
+            }
+        }
+
+        [TestMethod]
+        public void CopyCudaToCpu()
+        {
+            var cuda = FloatTensor.Ones(new long[] { 2, 2 }, "cuda");
+            Assert.AreEqual(cuda.Device, "cuda");
+
+            var cpu = cuda.Cpu();
+            Assert.AreEqual(cpu.Device, "cpu");
+
+            var data = cpu.Data;
+            for (int i = 0; i < 4; i++)
+            {
+                Assert.AreEqual(data[i], 1);
+            }
+        }
+
+        [TestMethod]
         public void ScoreModel()
         {
             var ones = FloatTensor.Ones(new long[] { 1, 3, 224, 224 });

--- a/TorchSharp/Generated/TorchTensor.generated.cs
+++ b/TorchSharp/Generated/TorchTensor.generated.cs
@@ -1,8 +1,4 @@
-﻿
-
-
-
-using System;
+﻿using System;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
@@ -10,7 +6,6 @@ using System.Text;
 [assembly: InternalsVisibleTo("Test")]
 
 namespace TorchSharp.Tensor {
-
 
     /// <summary>
     ///   Tensor of type Byte.
@@ -183,6 +178,22 @@ namespace TorchSharp.Tensor {
             }
         }
 
+        [DllImport("LibTorchSharp")]
+        extern static IntPtr THS_cpu(IntPtr handle);
+
+         public ITorchTensor<byte> Cpu()
+        {
+            return new ByteTensor(THS_cpu(handle));
+        }
+
+         [DllImport("LibTorchSharp")]
+        extern static IntPtr THS_cuda(IntPtr handle);
+
+         public ITorchTensor<byte> Cuda()
+        {
+            return new ByteTensor(THS_cuda(handle));
+        }
+
         /// <summary>
         ///  Retrieves the size of the specified dimension in the tensor.
         /// </summary>
@@ -346,7 +357,6 @@ namespace TorchSharp.Tensor {
             return sb.ToString();
         }
     }
-
     /// <summary>
     ///   Tensor of type Short.
     ///   This tensor maps to a Torch variable (see torch/csrc/autograd/variable.h).
@@ -518,6 +528,22 @@ namespace TorchSharp.Tensor {
             }
         }
 
+        [DllImport("LibTorchSharp")]
+        extern static IntPtr THS_cpu(IntPtr handle);
+
+         public ITorchTensor<short> Cpu()
+        {
+            return new ShortTensor(THS_cpu(handle));
+        }
+
+         [DllImport("LibTorchSharp")]
+        extern static IntPtr THS_cuda(IntPtr handle);
+
+         public ITorchTensor<short> Cuda()
+        {
+            return new ShortTensor(THS_cuda(handle));
+        }
+
         /// <summary>
         ///  Retrieves the size of the specified dimension in the tensor.
         /// </summary>
@@ -681,7 +707,6 @@ namespace TorchSharp.Tensor {
             return sb.ToString();
         }
     }
-
     /// <summary>
     ///   Tensor of type Int.
     ///   This tensor maps to a Torch variable (see torch/csrc/autograd/variable.h).
@@ -853,6 +878,22 @@ namespace TorchSharp.Tensor {
             }
         }
 
+        [DllImport("LibTorchSharp")]
+        extern static IntPtr THS_cpu(IntPtr handle);
+
+         public ITorchTensor<int> Cpu()
+        {
+            return new IntTensor(THS_cpu(handle));
+        }
+
+         [DllImport("LibTorchSharp")]
+        extern static IntPtr THS_cuda(IntPtr handle);
+
+         public ITorchTensor<int> Cuda()
+        {
+            return new IntTensor(THS_cuda(handle));
+        }
+
         /// <summary>
         ///  Retrieves the size of the specified dimension in the tensor.
         /// </summary>
@@ -1016,7 +1057,6 @@ namespace TorchSharp.Tensor {
             return sb.ToString();
         }
     }
-
     /// <summary>
     ///   Tensor of type Long.
     ///   This tensor maps to a Torch variable (see torch/csrc/autograd/variable.h).
@@ -1188,6 +1228,22 @@ namespace TorchSharp.Tensor {
             }
         }
 
+        [DllImport("LibTorchSharp")]
+        extern static IntPtr THS_cpu(IntPtr handle);
+
+         public ITorchTensor<long> Cpu()
+        {
+            return new LongTensor(THS_cpu(handle));
+        }
+
+         [DllImport("LibTorchSharp")]
+        extern static IntPtr THS_cuda(IntPtr handle);
+
+         public ITorchTensor<long> Cuda()
+        {
+            return new LongTensor(THS_cuda(handle));
+        }
+
         /// <summary>
         ///  Retrieves the size of the specified dimension in the tensor.
         /// </summary>
@@ -1351,7 +1407,6 @@ namespace TorchSharp.Tensor {
             return sb.ToString();
         }
     }
-
     /// <summary>
     ///   Tensor of type Double.
     ///   This tensor maps to a Torch variable (see torch/csrc/autograd/variable.h).
@@ -1523,6 +1578,22 @@ namespace TorchSharp.Tensor {
             }
         }
 
+        [DllImport("LibTorchSharp")]
+        extern static IntPtr THS_cpu(IntPtr handle);
+
+         public ITorchTensor<double> Cpu()
+        {
+            return new DoubleTensor(THS_cpu(handle));
+        }
+
+         [DllImport("LibTorchSharp")]
+        extern static IntPtr THS_cuda(IntPtr handle);
+
+         public ITorchTensor<double> Cuda()
+        {
+            return new DoubleTensor(THS_cuda(handle));
+        }
+
         /// <summary>
         ///  Retrieves the size of the specified dimension in the tensor.
         /// </summary>
@@ -1686,7 +1757,6 @@ namespace TorchSharp.Tensor {
             return sb.ToString();
         }
     }
-
     /// <summary>
     ///   Tensor of type Float.
     ///   This tensor maps to a Torch variable (see torch/csrc/autograd/variable.h).
@@ -1858,6 +1928,22 @@ namespace TorchSharp.Tensor {
             }
         }
 
+        [DllImport("LibTorchSharp")]
+        extern static IntPtr THS_cpu(IntPtr handle);
+
+         public ITorchTensor<float> Cpu()
+        {
+            return new FloatTensor(THS_cpu(handle));
+        }
+
+         [DllImport("LibTorchSharp")]
+        extern static IntPtr THS_cuda(IntPtr handle);
+
+         public ITorchTensor<float> Cuda()
+        {
+            return new FloatTensor(THS_cuda(handle));
+        }
+
         /// <summary>
         ///  Retrieves the size of the specified dimension in the tensor.
         /// </summary>
@@ -2021,7 +2107,6 @@ namespace TorchSharp.Tensor {
             return sb.ToString();
         }
     }
-
     
     public enum ATenScalarMapping : sbyte
     {
@@ -2039,37 +2124,30 @@ namespace TorchSharp.Tensor {
         {
             switch (true)
             {
-
                 case bool _ when typeof(T) == typeof(byte):
                 {
                     return new ByteTensor(rawTensor) as ITorchTensor<T>;
                 }
-
                 case bool _ when typeof(T) == typeof(short):
                 {
                     return new ShortTensor(rawTensor) as ITorchTensor<T>;
                 }
-
                 case bool _ when typeof(T) == typeof(int):
                 {
                     return new IntTensor(rawTensor) as ITorchTensor<T>;
                 }
-
                 case bool _ when typeof(T) == typeof(long):
                 {
                     return new LongTensor(rawTensor) as ITorchTensor<T>;
                 }
-
                 case bool _ when typeof(T) == typeof(double):
                 {
                     return new DoubleTensor(rawTensor) as ITorchTensor<T>;
                 }
-
                 case bool _ when typeof(T) == typeof(float):
                 {
                     return new FloatTensor(rawTensor) as ITorchTensor<T>;
                 }
-
                 default: throw new NotImplementedException($"Creating tensor of type {typeof(T)} is not supported.");
             }
         }
@@ -2078,37 +2156,30 @@ namespace TorchSharp.Tensor {
         {
             switch (true)
             {
-
                 case bool _ when typeof(T) == typeof(byte):
                 {
                     return ByteTensor.From(rawArray as byte[], dimensions) as ITorchTensor<T>;
                 }
-
                 case bool _ when typeof(T) == typeof(short):
                 {
                     return ShortTensor.From(rawArray as short[], dimensions) as ITorchTensor<T>;
                 }
-
                 case bool _ when typeof(T) == typeof(int):
                 {
                     return IntTensor.From(rawArray as int[], dimensions) as ITorchTensor<T>;
                 }
-
                 case bool _ when typeof(T) == typeof(long):
                 {
                     return LongTensor.From(rawArray as long[], dimensions) as ITorchTensor<T>;
                 }
-
                 case bool _ when typeof(T) == typeof(double):
                 {
                     return DoubleTensor.From(rawArray as double[], dimensions) as ITorchTensor<T>;
                 }
-
                 case bool _ when typeof(T) == typeof(float):
                 {
                     return FloatTensor.From(rawArray as float[], dimensions) as ITorchTensor<T>;
                 }
-
                 default: throw new NotImplementedException($"Creating tensor of type {typeof(T)} is not supported.");
             }
         }
@@ -2117,37 +2188,30 @@ namespace TorchSharp.Tensor {
         {
             switch (true)
             {
-
                 case bool _ when typeof(T) == typeof(byte):
                 {
                     return ByteTensor.From((byte)(object)scalar) as ITorchTensor<T>;
                 }
-
                 case bool _ when typeof(T) == typeof(short):
                 {
                     return ShortTensor.From((short)(object)scalar) as ITorchTensor<T>;
                 }
-
                 case bool _ when typeof(T) == typeof(int):
                 {
                     return IntTensor.From((int)(object)scalar) as ITorchTensor<T>;
                 }
-
                 case bool _ when typeof(T) == typeof(long):
                 {
                     return LongTensor.From((long)(object)scalar) as ITorchTensor<T>;
                 }
-
                 case bool _ when typeof(T) == typeof(double):
                 {
                     return DoubleTensor.From((double)(object)scalar) as ITorchTensor<T>;
                 }
-
                 case bool _ when typeof(T) == typeof(float):
                 {
                     return FloatTensor.From((float)(object)scalar) as ITorchTensor<T>;
                 }
-
                 default: throw new NotImplementedException($"Creating tensor of type {typeof(T)} is not supported.");
             }
         }

--- a/TorchSharp/Generated/TorchTensor.tt
+++ b/TorchSharp/Generated/TorchTensor.tt
@@ -185,6 +185,22 @@ foreach (var type in TorchTypeDef.Types) {
             }
         }
 
+        [DllImport("LibTorchSharp")]
+        extern static IntPtr THS_cpu(IntPtr handle);
+
+         public ITorchTensor<<#=type.Storage#>> Cpu()
+        {
+            return new <#=type.Name#>Tensor(THS_cpu(handle));
+        }
+
+         [DllImport("LibTorchSharp")]
+        extern static IntPtr THS_cuda(IntPtr handle);
+
+         public ITorchTensor<<#=type.Storage#>> Cuda()
+        {
+            return new <#=type.Name#>Tensor(THS_cuda(handle));
+        }
+
         /// <summary>
         ///  Retrieves the size of the specified dimension in the tensor.
         /// </summary>

--- a/TorchSharp/Tensor/ITorchTensor.cs
+++ b/TorchSharp/Tensor/ITorchTensor.cs
@@ -14,6 +14,10 @@ namespace TorchSharp.Tensor
 
         string Device { get; }
 
+        ITorchTensor<T> Cpu();
+
+        ITorchTensor<T> Cuda();
+
         Span<T> Data { get; }
 
         T Item { get; }


### PR DESCRIPTION
This PR adds functions for transferring tensors between CPU and CUDA devices.
I commented this [line](https://github.com/interesaaat/TorchSharp/blob/LibTorchSharpFirstTest/TorchSharp/Generated/TorchTensor.generated.cs#L10) to avoid build error.
We need to extend this transfer function later to support multiple CUDA devices (e.g., "cuda:3").
