### PR TITLE
Add the ability to specify loss functions as delegates

### DIFF
--- a/Test/TorchSharp/TorchSharp.cs
+++ b/Test/TorchSharp/TorchSharp.cs
@@ -431,9 +431,10 @@ namespace TorchSharp.Test
             var y = FloatTensor.RandomN(new long[] { 64, 10 }, device: "cpu:0");
 
             var eval = seq.Forward(x);
-            var loss = NN.LossFunction.MSE(eval, y, NN.Reduction.Sum);
+            var loss = NN.LossFunction.MSE(NN.Reduction.Sum);
+            var output = loss(eval, y);
 
-            var result = loss.DataItem<float>();
+            var result = output.DataItem<float>();
             Assert.IsNotNull(result);
         }
 
@@ -444,9 +445,9 @@ namespace TorchSharp.Test
             using (TorchTensor target = FloatTensor.From(new float[] { 1f, 2f, 3f }))
             {
                 var componentWiseLoss = ((TorchTensor)input.Exp()) - target * input;
-                Assert.IsTrue(componentWiseLoss.Equal(NN.LossFunction.PoissonNLL(input, target, reduction: NN.Reduction.None)));
-                Assert.IsTrue(componentWiseLoss.Sum().Equal(NN.LossFunction.PoissonNLL(input, target, reduction: NN.Reduction.Sum)));
-                Assert.IsTrue(componentWiseLoss.Mean().Equal(NN.LossFunction.PoissonNLL(input, target, reduction: NN.Reduction.Mean)));
+                Assert.IsTrue(componentWiseLoss.Equal(NN.LossFunction.PoissonNLL(reduction: NN.Reduction.None)(input, target)));
+                Assert.IsTrue(componentWiseLoss.Sum().Equal(NN.LossFunction.PoissonNLL(reduction: NN.Reduction.Sum)(input, target)));
+                Assert.IsTrue(componentWiseLoss.Mean().Equal(NN.LossFunction.PoissonNLL(reduction: NN.Reduction.Mean)(input, target)));
             }
         }
 
@@ -456,7 +457,7 @@ namespace TorchSharp.Test
             using (TorchTensor input = FloatTensor.Random(new long[] { 5, 2 }))
             using (TorchTensor target = FloatTensor.Random(new long[] { 5, 2 }))
             {
-                Assert.IsNotNull(NN.LossFunction.PoissonNLL(input, target, true, true));
+                Assert.IsNotNull(NN.LossFunction.PoissonNLL(true, true)(input, target));
             }
         }
 
@@ -481,11 +482,12 @@ namespace TorchSharp.Test
             var y = FloatTensor.RandomN(new long[] { 64, 10 }, device: "cpu:0");
 
             var eval = seq.Forward(x);
-            var loss = NN.LossFunction.MSE(eval, y, NN.Reduction.None);
+            var loss = NN.LossFunction.MSE(NN.Reduction.None);
+            var output = loss(eval, y);
 
             seq.ZeroGrad();
 
-            loss.Backward();
+            output.Backward();
         }
 
         [TestMethod]
@@ -499,11 +501,12 @@ namespace TorchSharp.Test
             var y = FloatTensor.RandomN(new long[] { 64, 10 }, device: "cpu:0");
 
             var eval = seq.Forward(x);
-            var loss = NN.LossFunction.MSE(eval, y, NN.Reduction.None);
+            var loss = NN.LossFunction.MSE(NN.Reduction.None);
+            var output = loss(eval, y);
 
             seq.ZeroGrad();
 
-            loss.Backward();
+            output.Backward();
 
             foreach (var parm in seq.Parameters())
             {
@@ -522,11 +525,12 @@ namespace TorchSharp.Test
             var y = FloatTensor.RandomN(new long[] { 64, 10 }, device: "cpu:0");
 
             var eval = seq.Forward(x);
-            var loss = NN.LossFunction.MSE(eval, y, NN.Reduction.None);
+            var loss = NN.LossFunction.MSE(NN.Reduction.None);
+            var output = loss(eval, y);
 
             seq.ZeroGrad();
 
-            loss.Backward();
+            output.Backward();
 
             foreach (var parm in seq.Parameters())
             {
@@ -658,19 +662,20 @@ namespace TorchSharp.Test
 
             float learning_rate = 0.00004f;
             float prevLoss = float.MaxValue;
+            var loss = NN.LossFunction.MSE(NN.Reduction.Sum);
 
             for (int i = 0; i < 10; i++)
             {
                 var eval = seq.Forward(x);
-                var loss = NN.LossFunction.MSE(eval, y, NN.Reduction.Sum);
-                var lossVal = loss.DataItem<float>();
+                var output = loss(eval, y);
+                var lossVal = output.DataItem<float>();
 
                 Assert.IsTrue(lossVal < prevLoss);
                 prevLoss = lossVal;
 
                 seq.ZeroGrad();
 
-                loss.Backward();
+                output.Backward();
 
                 using (var noGrad = new AutoGradMode(false))
                 {
@@ -704,37 +709,6 @@ namespace TorchSharp.Test
         /// </summary>
         [TestMethod]
         public void TestTrainingAdam()
-        {
-            var lin1 = NN.Module.Linear(1000, 100);
-            var lin2 = NN.Module.Linear(100, 10);
-            var seq = NN.Module.Sequential(lin1, NN.Module.Relu(), lin2);
-
-            var x = FloatTensor.RandomN(new long[] { 64, 1000 }, device: "cpu:0");
-            var y = FloatTensor.RandomN(new long[] { 64, 10 }, device: "cpu:0");
-
-            double learning_rate = 0.00004f;
-            float prevLoss = float.MaxValue;
-            var optimizer = NN.Optimizer.Adam(seq.Parameters(), learning_rate);
-
-            for (int i = 0; i < 10; i++)
-            {
-                var eval = seq.Forward(x);
-                var loss = NN.LossFunction.MSE(eval, y, NN.Reduction.Sum);
-                var lossVal = loss.DataItem<float>();
-
-                Assert.IsTrue(lossVal < prevLoss);
-                prevLoss = lossVal;
-
-                optimizer.ZeroGrad();
-
-                loss.Backward();
-
-                optimizer.Step();
-            }
-        }
-
-        [TestMethod]
-        public void TestTrainingAdam2()
         {
             var lin1 = NN.Module.Linear(1000, 100);
             var lin2 = NN.Module.Linear(100, 10);

--- a/TorchSharp/NN/LossFunction.cs
+++ b/TorchSharp/NN/LossFunction.cs
@@ -14,11 +14,6 @@ namespace TorchSharp.NN
         [DllImport("libTorchSharp")]
         extern static IntPtr THSNN_lossBCE(IntPtr srct, IntPtr trgt, IntPtr wgt, long reduction);
 
-        public static TorchTensor BCE(TorchTensor src, TorchTensor target, TorchTensor? weigths = null, Reduction reduction = Reduction.Mean)
-        {
-            return new TorchTensor(THSNN_lossBCE(src.Handle, target.Handle, weigths?.Handle ?? IntPtr.Zero, (long)reduction));
-        }
-
         public static Loss BCE(TorchTensor? weigths = null, Reduction reduction = Reduction.Mean)
         {
             return (TorchTensor src, TorchTensor target) => new TorchTensor(THSNN_lossBCE(src.Handle, target.Handle, weigths?.Handle ?? IntPtr.Zero, (long)reduction));
@@ -26,11 +21,6 @@ namespace TorchSharp.NN
 
         [DllImport("libTorchSharp")]
         extern static IntPtr THSNN_lossMSE(IntPtr srct, IntPtr trgt, long reduction);
-
-        public static TorchTensor MSE(TorchTensor src, TorchTensor target, Reduction reduction = Reduction.Mean)
-        {
-            return new TorchTensor(THSNN_lossMSE(src.Handle, target.Handle, (long)reduction));
-        }
 
         public static Loss MSE(Reduction reduction = Reduction.Mean)
         {
@@ -40,11 +30,6 @@ namespace TorchSharp.NN
         [DllImport("libTorchSharp")]
         extern static IntPtr THSNN_lossNLL(IntPtr srct, IntPtr trgt, IntPtr wgt, long reduction);
 
-        public static TorchTensor NLL(TorchTensor src, TorchTensor target, TorchTensor? weigths = null, Reduction reduction = Reduction.Mean)
-        {
-            return new TorchTensor(THSNN_lossNLL(src.Handle, target.Handle, weigths?.Handle ?? IntPtr.Zero, (long)reduction));
-        }
-
         public static Loss NLL(TorchTensor? weigths = null, Reduction reduction = Reduction.Mean)
         {
             return (TorchTensor src, TorchTensor target) => new TorchTensor(THSNN_lossNLL(src.Handle, target.Handle, weigths?.Handle ?? IntPtr.Zero, (long)reduction));
@@ -52,11 +37,6 @@ namespace TorchSharp.NN
 
         [DllImport("libTorchSharp")]
         extern static IntPtr THSNN_lossPoissonNLL(IntPtr srct, IntPtr trgt, bool logInput, bool full, float eps, long reduction);
-
-        public static TorchTensor PoissonNLL(TorchTensor src, TorchTensor target, bool logInput = true, bool full = false, float eps = 1e-8f, Reduction reduction = Reduction.Mean)
-        {
-            return new TorchTensor(THSNN_lossPoissonNLL(src.Handle, target.Handle, logInput, full, eps, (long)reduction));
-        }
 
         public static Loss PoissonNLL(bool logInput = true, bool full = false, float eps = 1e-8f, Reduction reduction = Reduction.Mean)
         {

--- a/TorchSharp/NN/LossFunction.cs
+++ b/TorchSharp/NN/LossFunction.cs
@@ -9,12 +9,19 @@ namespace TorchSharp.NN
     /// </summary>
     public class LossFunction
     {
+        public delegate TorchTensor Loss(TorchTensor source, TorchTensor target);
+
         [DllImport("libTorchSharp")]
         extern static IntPtr THSNN_lossBCE(IntPtr srct, IntPtr trgt, IntPtr wgt, long reduction);
 
-        public static TorchTensor BCE<T, U>(TorchTensor src, TorchTensor target, TorchTensor? weigths = null, Reduction reduction = Reduction.Mean)
+        public static TorchTensor BCE(TorchTensor src, TorchTensor target, TorchTensor? weigths = null, Reduction reduction = Reduction.Mean)
         {
             return new TorchTensor(THSNN_lossBCE(src.Handle, target.Handle, weigths?.Handle ?? IntPtr.Zero, (long)reduction));
+        }
+
+        public static Loss BCE(TorchTensor? weigths = null, Reduction reduction = Reduction.Mean)
+        {
+            return (TorchTensor src, TorchTensor target) => new TorchTensor(THSNN_lossBCE(src.Handle, target.Handle, weigths?.Handle ?? IntPtr.Zero, (long)reduction));
         }
 
         [DllImport("libTorchSharp")]
@@ -25,6 +32,11 @@ namespace TorchSharp.NN
             return new TorchTensor(THSNN_lossMSE(src.Handle, target.Handle, (long)reduction));
         }
 
+        public static Loss MSE(Reduction reduction = Reduction.Mean)
+        {
+            return (TorchTensor src, TorchTensor target) => new TorchTensor(THSNN_lossMSE(src.Handle, target.Handle, (long)reduction));
+        }
+
         [DllImport("libTorchSharp")]
         extern static IntPtr THSNN_lossNLL(IntPtr srct, IntPtr trgt, IntPtr wgt, long reduction);
 
@@ -33,12 +45,22 @@ namespace TorchSharp.NN
             return new TorchTensor(THSNN_lossNLL(src.Handle, target.Handle, weigths?.Handle ?? IntPtr.Zero, (long)reduction));
         }
 
+        public static Loss NLL(TorchTensor? weigths = null, Reduction reduction = Reduction.Mean)
+        {
+            return (TorchTensor src, TorchTensor target) => new TorchTensor(THSNN_lossNLL(src.Handle, target.Handle, weigths?.Handle ?? IntPtr.Zero, (long)reduction));
+        }
+
         [DllImport("libTorchSharp")]
         extern static IntPtr THSNN_lossPoissonNLL(IntPtr srct, IntPtr trgt, bool logInput, bool full, float eps, long reduction);
 
         public static TorchTensor PoissonNLL(TorchTensor src, TorchTensor target, bool logInput = true, bool full = false, float eps = 1e-8f, Reduction reduction = Reduction.Mean)
         {
             return new TorchTensor(THSNN_lossPoissonNLL(src.Handle, target.Handle, logInput, full, eps, (long)reduction));
+        }
+
+        public static Loss PoissonNLL(bool logInput = true, bool full = false, float eps = 1e-8f, Reduction reduction = Reduction.Mean)
+        {
+            return (TorchTensor src, TorchTensor target) => new TorchTensor(THSNN_lossPoissonNLL(src.Handle, target.Handle, logInput, full, eps, (long)reduction));
         }
     }
 


### PR DESCRIPTION
This PR allows to match the python interface when specifying the loss function.

Fix #17.